### PR TITLE
不要なファイルを生成しない設定

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@
 # Ignore Byebug command history file.
 .byebug_history
 config/secrets.yml
+
+public/uploads/*

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,5 +11,11 @@ module FreemarketSample62d
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
+    config.generators do |g|
+      g.stylesheets false
+      g.javascripts false
+      g.helper false
+      g.test_framework false
+    end
   end
 end


### PR DESCRIPTION
##WHAT
不要なファイルを生成しないように設定した
chatspaceでの設定に準じてcoffee.jsなどのファイルを生成しない設定
gitignoreにローカル環境でしようしたimagefileなどをgitにあげないように設定


##WHY
・今後画像を扱って行くことが多いため、imagefileがないことで発生するエラーを未然に防ぐ
・coffee.jsなどの不要なファイルは可読性を悪くするため
・プルリクエストでメンターさんから不要なファイルを消しましょうとレビューをいただくことが多かった
上記のことからこの設定を行う