### PR TITLE
マイページのプロフィール画面のマークアップ

### DIFF
--- a/app/assets/stylesheets/profile.scss
+++ b/app/assets/stylesheets/profile.scss
@@ -1,52 +1,54 @@
-.mypage__profile-title {
-  font-family: 'Source Sans Pro', Helvetica , Arial, '游ゴシック体', 'YuGothic', 'メイリオ', 'Meiryo', sans-serif;
-  border-bottom: 1px solid #f5f5f5;
-  background-color: #ffffff;
-  text-align: center;
-  font-weight: bold;
-  padding: 8px 24px;
-  line-height: 1.4;
-  font-size: 18px;
-  font-size: 24px;
-  color: #333;
-}
-.mypage__profile-imagebox {
-  background: url("https://www.mercari.com/jp/assets/img/mypage/user-bg.jpg?79784477");
-  background-repeat: no-repeat;
-  background-size: cover;
-  position: relative;
-  height: 156px;
-  .mypage__profile-user {
-    justify-content: center;
-    padding: 72px 16px 24px;
+.mypage__content {
+  &-title {
+    font-family: 'Source Sans Pro', Helvetica , Arial, '游ゴシック体', 'YuGothic', 'メイリオ', 'Meiryo', sans-serif;
+    border-bottom: 1px solid #f5f5f5;
+    background-color: #ffffff;
     text-align: center;
-    line-height: 60px;
-    display: flex;
-    height: 60px;
-    width: 100%;
-    img {
-      border-radius: 50%;
-      overflow: hidden;
+    font-weight: bold;
+    padding: 8px 24px;
+    line-height: 1.4;
+    font-size: 18px;
+    font-size: 24px;
+    color: #333;
+  }
+
+  &-imagebox {
+    background: url("https://www.mercari.com/jp/assets/img/mypage/user-bg.jpg?79784477");
+    background-repeat: no-repeat;
+    background-size: cover;
+    position: relative;
+    height: 156px;
+    &-user {
+      justify-content: center;
+      padding: 72px 16px 24px;
+      text-align: center;
+      line-height: 60px;
+      display: flex;
       height: 60px;
-      width: 60px;
-    }
-    input.mypage__profile-user--name {
-      border: 1px solid #ccc;
-      margin: auto 0 auto 8px;
-      padding: 10px 16px 8px;
-      border-radius: 4px;
-      background: #fff;
-      font-size: 16px;
-      height: 28px;
-      width: 186px;
+      width: 100%;
+      img {
+        border-radius: 50%;
+        overflow: hidden;
+        height: 60px;
+        width: 60px;
+      }
+      &--name {
+        border: 1px solid #ccc;
+        margin: auto 0 auto 8px;
+        padding: 10px 16px 8px;
+        border-radius: 4px;
+        background: #fff;
+        font-size: 16px;
+        height: 28px;
+        width: 186px;
+      }
     }
   }
-}
-.mypage__profile-formcontents {
-  background-color: #fff;
-  padding: 40px 16px;
-  .mypage__profile-form {
-    .mypage__profile-form-text {
+
+  &-form {
+    background-color: #fff;
+    padding: 40px 16px;
+    &--text {
       border: 1px solid #ccc;
       background-color: #fff;
       box-sizing: border-box;
@@ -57,20 +59,20 @@
       padding: 10px;
       width: 100%;
     }
-  }
-  .mypage__profile-btn {
-    background-color: #ea352d;
-    border: 1px solid #ea352d;
-    text-align: center;
-    line-height: 48px;
-    margin-top: 16px;
-    font-size: 14px;
-    transition: all;
-    cursor: pointer;
-    color: #fff;
-    width: 100%;
-    a:visited {
+    &--btn {
+      background-color: #ea352d;
+      border: 1px solid #ea352d;
+      text-align: center;
+      line-height: 48px;
+      margin-top: 16px;
+      font-size: 14px;
+      transition: all;
+      cursor: pointer;
       color: #fff;
+      width: 100%;
+      a:visited {
+        color: #fff;
+      }
     }
   }
 }

--- a/app/assets/stylesheets/profile.scss
+++ b/app/assets/stylesheets/profile.scss
@@ -1,0 +1,76 @@
+.mypage__profile-title {
+  font-family: 'Source Sans Pro', Helvetica , Arial, '游ゴシック体', 'YuGothic', 'メイリオ', 'Meiryo', sans-serif;
+  border-bottom: 1px solid #f5f5f5;
+  background-color: #ffffff;
+  text-align: center;
+  font-weight: bold;
+  padding: 8px 24px;
+  line-height: 1.4;
+  font-size: 18px;
+  font-size: 24px;
+  color: #333;
+}
+.mypage__profile-imagebox {
+  background: url("https://www.mercari.com/jp/assets/img/mypage/user-bg.jpg?79784477");
+  background-repeat: no-repeat;
+  background-size: cover;
+  position: relative;
+  height: 156px;
+  .mypage__profile-user {
+    justify-content: center;
+    padding: 72px 16px 24px;
+    text-align: center;
+    line-height: 60px;
+    display: flex;
+    height: 60px;
+    width: 100%;
+    img {
+      border-radius: 50%;
+      overflow: hidden;
+      height: 60px;
+      width: 60px;
+    }
+    input.mypage__profile-user--name {
+      border: 1px solid #ccc;
+      margin: auto 0 auto 8px;
+      padding: 10px 16px 8px;
+      border-radius: 4px;
+      background: #fff;
+      font-size: 16px;
+      height: 28px;
+      width: 186px;
+    }
+  }
+}
+.mypage__profile-formcontents {
+  background-color: #fff;
+  padding: 40px 16px;
+  .mypage__profile-form {
+    .mypage__profile-form-text {
+      border: 1px solid #ccc;
+      background-color: #fff;
+      box-sizing: border-box;
+      min-height: 216px;
+      line-height: 1.5;
+      font-size: 16px;
+      max-width: 100%;
+      padding: 10px;
+      width: 100%;
+    }
+  }
+  .mypage__profile-btn {
+    background-color: #ea352d;
+    border: 1px solid #ea352d;
+    text-align: center;
+    line-height: 48px;
+    margin-top: 16px;
+    font-size: 14px;
+    transition: all;
+    cursor: pointer;
+    color: #fff;
+    width: 100%;
+    a:visited {
+      color: #fff;
+    }
+  }
+}

--- a/app/assets/stylesheets/user/logout.scss
+++ b/app/assets/stylesheets/user/logout.scss
@@ -12,7 +12,7 @@
       height: 50px;
       background: #ea352d;
       text-align: center;
-      color: #fff;
+      color: rgb(17, 17, 17);
       border: 1px;
       margin:0 auto;
       font-size:14px;

--- a/app/controllers/mypage_controller.rb
+++ b/app/controllers/mypage_controller.rb
@@ -25,4 +25,7 @@ class MypageController < ApplicationController
 
   def edit
   end
+
+  def profile
+  end
 end

--- a/app/views/homes/_header.html.haml
+++ b/app/views/homes/_header.html.haml
@@ -1,10 +1,11 @@
 .header-wrapper
   .header
     .header__logo-search
-      =image_tag "/SVG/fmarket_logo_red.svg", class: "header__logo-search--logo"
-      %form.header__form
-        %input{value:"", placeholder:"何かお探しですか？", class:"header__form--input"}
-        %i.fa.fa-search
+      =link_to "root" do
+        =image_tag "/SVG/fmarket_logo_red.svg", class: "header__logo-search--logo"
+        %form.header__form
+          %input{value:"", placeholder:"何かお探しですか？", class:"header__form--input"}
+          %i.fa.fa-search
     .header-lists
       %ul.header-lists__left
         %li.header__item(id="header-category")

--- a/app/views/mypage/_nav.html.haml
+++ b/app/views/mypage/_nav.html.haml
@@ -72,7 +72,7 @@
     設定
   %ul.mypage-nav__list
     %li
-      =link_to "/mypage/profile/", class:"mypage-nav__list--item" do
+      =link_to "/mypage/profile/", class:"mypage-nav__list--item #{controller.action_name == "profile" ? 'active' : ''}" do
         プロフィール
         =fa_icon 'chevron-right'
     %li
@@ -88,7 +88,7 @@
         メール/パスワード
         =fa_icon 'chevron-right'
     %li
-      =link_to "/mypage/identification/", class:"mypage-nav__list--item" do
+      =link_to "/mypage/identification/", class:"mypage-nav__list--item #{controller.action_name == "identification" ? 'active' : ''}"do
         本人情報
         =fa_icon 'chevron-right'
     %li

--- a/app/views/mypage/profile.html.haml
+++ b/app/views/mypage/profile.html.haml
@@ -1,0 +1,1 @@
+hello world

--- a/app/views/mypage/profile.html.haml
+++ b/app/views/mypage/profile.html.haml
@@ -1,3 +1,4 @@
+=render "homes/sell-btn"
 .mypage-wrapper
   .mypage.clearfix
     =render 'mypage/nav'

--- a/app/views/mypage/profile.html.haml
+++ b/app/views/mypage/profile.html.haml
@@ -2,15 +2,14 @@
   .mypage.clearfix
     =render 'mypage/nav'
     .mypage__content
-      .mypage__profile-title
+      .mypage__content-title
         プロフィール
-      .mypage__profile-imagebox
-        %section.mypage__profile-user
-          =link_to "ユーザーid毎のページurl",  class:"mypage__profile-user--link" do
+      .mypage__content-imagebox
+        %section.mypage__content-imagebox-user
+          =link_to "ユーザーid毎のページurl",  class:"mypage__content-user--link" do
             = image_tag "//static.mercdn.net/images/member_photo_noimage_thumb.png", width:"60", height:"60"
-          %input.mypage__profile-user--name 
-      .mypage__profile-formcontents
-        .mypage__profile-form
-          %textarea{value:"", placeholder: "例)  こんにちは☆ ご覧いただきありがとうございmす！かわいいものやきれいめオフィスカジュアル中心に出品しています。服のサイズは主に9号です。気持ちよくお取り引きできるよう心がけていますので、商品や発送方法などご質問ありましたらお気軽にどうぞ♪", class:"mypage__profile-form-text"}
-        .mypage__profile-btn
+          %input.mypage__content-imagebox-user--name 
+      .mypage__content-form
+        %textarea{value:"", placeholder: "例)  こんにちは☆ ご覧いただきありがとうございmす！かわいいものやきれいめオフィスカジュアル中心に出品しています。服のサイズは主に9号です。気持ちよくお取り引きできるよう心がけていますので、商品や発送方法などご質問ありましたらお気軽にどうぞ♪", class:"mypage__content-form--text"}
+        .mypage__content-form--btn
           =link_to '変更する'

--- a/app/views/mypage/profile.html.haml
+++ b/app/views/mypage/profile.html.haml
@@ -1,1 +1,16 @@
-hello world
+.mypage-wrapper
+  .mypage.clearfix
+    =render 'mypage/nav'
+    .mypage__content
+      .mypage__profile-title
+        プロフィール
+      .mypage__profile-imagebox
+        %section.mypage__profile-user
+          =link_to "ユーザーid毎のページurl",  class:"mypage__profile-user--link" do
+            = image_tag "//static.mercdn.net/images/member_photo_noimage_thumb.png", width:"60", height:"60"
+          %input.mypage__profile-user--name 
+      .mypage__profile-formcontents
+        .mypage__profile-form
+          %textarea{value:"", placeholder: "例)  こんにちは☆ ご覧いただきありがとうございmす！かわいいものやきれいめオフィスカジュアル中心に出品しています。服のサイズは主に9号です。気持ちよくお取り引きできるよう心がけていますので、商品や発送方法などご質問ありましたらお気軽にどうぞ♪", class:"mypage__profile-form-text"}
+        .mypage__profile-btn
+          =link_to '変更する'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
       get 'purchased' => 'mypage#purchased'
       get 'logout' => 'mypage#logout'
       get 'identification' =>'mypage#identification'
+      get 'profile' => 'mypage#profile'
       namespace :card do
         get '/' => '/mypage/card#index'
         get 'new' => '/mypage/card#new'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  get 'root' => 'homes#index'
   # 石原
   # このファイルのコントローラは仮のため、ディレクトリ構造に合わせて各ビュー内のパスも合わせる事。
   resources :mypage, only: :index do

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -18,6 +18,7 @@ ActiveRecord::Schema.define(version: 20191122011259) do
     t.string   "address",       null: false
     t.string   "building_name"
     t.string   "phone_number"
+    t.integer  "user_id",       null: false
     t.datetime "created_at",    null: false
     t.datetime "updated_at",    null: false
   end
@@ -64,22 +65,25 @@ ActiveRecord::Schema.define(version: 20191122011259) do
   end
 
   create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.string   "email",                  default: "", null: false
-    t.string   "encrypted_password",     default: "", null: false
-    t.string   "firstname",                           null: false
-    t.string   "firstname_kana",                      null: false
-    t.string   "lastname",                            null: false
-    t.string   "lastname_kana",                       null: false
-    t.string   "nickname",                            null: false
-    t.date     "birthday",                            null: false
-    t.bigint   "total_profit",           default: 0
-    t.bigint   "point",                  default: 0
-    t.string   "user_profile"
+    t.string   "first_name",                                        null: false
+    t.string   "first_name_kana",                                   null: false
+    t.string   "last_name",                                         null: false
+    t.string   "last_name_kana",                                    null: false
+    t.string   "nickname",                                          null: false
+    t.string   "email",                                             null: false
+    t.string   "encrypted_password",                   default: "", null: false
+    t.integer  "birthdate_year",                                    null: false
+    t.integer  "birthdate_month",                                   null: false
+    t.integer  "birthdate_day",                                     null: false
+    t.bigint   "total_profit",                         default: 0
+    t.bigint   "point",                                default: 0
+    t.integer  "phone_number",                                      null: false
+    t.text     "user_profile",           limit: 65535
     t.string   "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.datetime "created_at",                          null: false
-    t.datetime "updated_at",                          null: false
+    t.datetime "created_at",                                        null: false
+    t.datetime "updated_at",                                        null: false
     t.index ["email"], name: "index_users_on_email", unique: true, using: :btree
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
   end


### PR DESCRIPTION
##WHAT
・マイページのプロフィール画面のマークアップ
・プロフィールページにいる場合にはナビバーのプロフィールをグレーにする
・textareaにてプロフィール入力箇所を配置
※全て仮置きのため、後ほどuserテーブルからアイコン、ニックネーム、プロフィールテキストを取得する必要あり
・軽微な修正としてヘッダーのロゴクリックでroot pathに遷移できるように設定
・本人情報ページにいる場合にはナビバーの本人情報の色をグレーにする

##WHY
・ユーザーが自身のニックネーム、プロフィールを編集できるようにするため
・現在いるページがわかりやすいように色を変更するため
・トップページに戻りやすいようにするため

[![Image from Gyazo](https://i.gyazo.com/45bc649d8d8ec6c435a5ae38d13a71ab.png)](https://gyazo.com/45bc649d8d8ec6c435a5ae38d13a71ab)