### PR TITLE
Edit breadcrumbs

### DIFF
--- a/app/assets/stylesheets/breadcrumbs.scss
+++ b/app/assets/stylesheets/breadcrumbs.scss
@@ -1,0 +1,7 @@
+.breadcrumbs-list {
+  font-family: "Source Sans Pro", Helvetica, Arial, 游ゴシック体, YuGothic, メイリオ, Meiryo, sans-serif;
+  font-size: 14px;
+  a:visited {
+    color: black;
+  }
+}

--- a/app/assets/stylesheets/user/logout.scss
+++ b/app/assets/stylesheets/user/logout.scss
@@ -21,6 +21,7 @@
       text-decoration: none;
       cursor: pointer;
       position: relative;
+      color: white;
       span{
         position: absolute;
         top: 50%;

--- a/app/views/mypage/_nav.html.haml
+++ b/app/views/mypage/_nav.html.haml
@@ -76,7 +76,7 @@
         プロフィール
         =fa_icon 'chevron-right'
     %li
-      =link_to "/mypage/deliver_address/", class:"mypage-nav__list--item" do
+      =link_to "/#", class:"mypage-nav__list--item" do #"/mypage/dliver_address/"
         発送元・お届け先住所変更
         =fa_icon 'chevron-right'
     %li
@@ -84,7 +84,7 @@
         支払い方法
         =fa_icon 'chevron-right'
     %li
-      =link_to "/mypage/email_password/", class:"mypage-nav__list--item" do
+      =link_to "/#", class:"mypage-nav__list--item" do #"/mypage/email_password/"
         メール/パスワード
         =fa_icon 'chevron-right'
     %li
@@ -92,7 +92,7 @@
         本人情報
         =fa_icon 'chevron-right'
     %li
-      =link_to "/mypage/sms_confirmation/", class:"mypage-nav__list--item" do
+      =link_to "/#", class:"mypage-nav__list--item" do  #"/mypage/sms_confirmation/"
         電話番号の確認
         =fa_icon 'chevron-right'
     %li

--- a/app/views/mypage/card/index.html.haml
+++ b/app/views/mypage/card/index.html.haml
@@ -1,3 +1,4 @@
+- breadcrumb :card
 .mypage-wrapper
   .mypage.clearfix
     = render '/mypage/nav'

--- a/app/views/mypage/identification.html.haml
+++ b/app/views/mypage/identification.html.haml
@@ -1,4 +1,4 @@
-- breadcrumb :profile
+- breadcrumb :identification
 .mypage-wrapper
   .mypage.clearfix
     = render 'nav'

--- a/app/views/mypage/listings/completed.html.haml
+++ b/app/views/mypage/listings/completed.html.haml
@@ -1,3 +1,4 @@
+- breadcrumb :completed
 .mypage-wrapper
   .mypage.clearfix
     = render '/mypage/nav'

--- a/app/views/mypage/listings/in_progress.html.haml
+++ b/app/views/mypage/listings/in_progress.html.haml
@@ -1,3 +1,4 @@
+- breadcrumb :in_progress
 .mypage-wrapper
   .mypage.clearfix
     = render '/mypage/nav'

--- a/app/views/mypage/listings/listing.html.haml
+++ b/app/views/mypage/listings/listing.html.haml
@@ -1,3 +1,4 @@
+- breadcrumb :listing
 .mypage-wrapper
   .mypage.clearfix
     = render '/mypage/nav'

--- a/app/views/mypage/logout.html.haml
+++ b/app/views/mypage/logout.html.haml
@@ -1,3 +1,4 @@
+- breadcrumb :logout
 .mypage-wrapper
   .mypage.clearfix
     =render 'mypage/nav'

--- a/app/views/mypage/nices/index.html.haml
+++ b/app/views/mypage/nices/index.html.haml
@@ -1,3 +1,4 @@
+- breadcrumb :nice_index
 .mypage-wrapper
   .mypage.clearfix
     = render '/mypage/nav'

--- a/app/views/mypage/notification.html.haml
+++ b/app/views/mypage/notification.html.haml
@@ -1,3 +1,4 @@
+- breadcrumb :notification
 .mypage-wrapper
   .mypage.clearfix
     = render 'nav'

--- a/app/views/mypage/profile.html.haml
+++ b/app/views/mypage/profile.html.haml
@@ -1,3 +1,4 @@
+- breadcrumb :profile
 =render "homes/sell-btn"
 .mypage-wrapper
   .mypage.clearfix

--- a/app/views/mypage/purchase.html.haml
+++ b/app/views/mypage/purchase.html.haml
@@ -1,3 +1,4 @@
+- breadcrumb :purchase
 .mypage-wrapper
   .mypage.clearfix
     = render 'nav'

--- a/app/views/mypage/purchased.html.haml
+++ b/app/views/mypage/purchased.html.haml
@@ -1,3 +1,4 @@
+- breadcrumb :purchased
 .mypage-wrapper
   .mypage.clearfix
     = render 'nav'

--- a/app/views/mypage/reviews/_review.html.haml
+++ b/app/views/mypage/reviews/_review.html.haml
@@ -1,3 +1,4 @@
+- breadcrumb :review_history
 %section.mypage__review
   .mypage__review--head
     評価一覧

--- a/app/views/mypage/todo.html.haml
+++ b/app/views/mypage/todo.html.haml
@@ -1,3 +1,4 @@
+- breadcrumb :todo
 .mypage-wrapper
   .mypage.clearfix
     = render 'nav'

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -6,11 +6,50 @@ crumb :mypage do
   link "マイページ", mypage_index_path
 end
 
-crumb :profile do 
-  link "プロフィール", root_path
+crumb :notification do
+  link "お知らせ", mypage_index_path
   parent :mypage
 end
 
+crumb :todo do
+  link "やることリスト", mypage_index_path
+  parent :mypage
+end
+
+crumb :nice_index do
+  link "いいね一覧", mypage_index_path
+  parent :mypage
+end
+
+crumb :listing do
+  link "出品した商品 - 出品中", mypage_index_path
+  parent :mypage
+end
+
+crumb :in_progress do
+  link "出品した商品 - 取引中", mypage_index_path
+  parent :mypage
+end
+
+crumb :completed do
+  link "出品した商品 - 売却済み", mypage_index_path
+  parent :mypage
+end
+
+crumb :purchase do
+  link "購入した商品 - 取引中", mypage_index_path
+  parent :mypage
+end
+
+crumb :purchased do
+  link "購入した商品 - 過去の取引", mypage_index_path
+  parent :mypage
+end
+
+crumb :profile do 
+  link "プロフィール", mypage_index_path
+  parent :mypage
+end
 # crumb :projects do
 #   link "Projects", projects_path
 # end

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -1,5 +1,5 @@
 crumb :root do
-  link "Fカリ", root_path
+  link "トップページ", root_path
 end
 
 crumb :mypage do

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -50,6 +50,21 @@ crumb :profile do
   link "プロフィール", mypage_index_path
   parent :mypage
 end
+
+crumb :card do 
+  link "支払い方法", mypage_index_path
+  parent :mypage
+end
+
+crumb :identification do 
+  link "本人情報の確認", mypage_index_path
+  parent :mypage
+end
+
+crumb :logout do 
+  link "ログアウト", mypage_index_path
+  parent :mypage
+end
 # crumb :projects do
 #   link "Projects", projects_path
 # end

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -65,6 +65,11 @@ crumb :logout do
   link "ログアウト", mypage_index_path
   parent :mypage
 end
+
+crumb :review_history do 
+  link "評価一覧", mypage_index_path
+  parent :mypage
+end
 # crumb :projects do
 #   link "Projects", projects_path
 # end


### PR DESCRIPTION
#WHAT
すでに山崎さんが実装してくださったパンくずで表示がされていなかった部分を実装
・マイページは全てパンくずが表示させるようになった
軽微な修正で以下の2点も行なった
・マイページのナビにてパスが通っていなかったものはトップページへのパスを通した
・ログアウトボタンのフォント色を白にした

#WHY
・ユーザーが現在どこのページを参照しているか一目でわかるようにするため
・パスが通っていない箇所に遷移してエラーが発生してしまうのを防ぐため
・ログアウトボタンのフォントの色が遷移後青くなってしまっていたため