### PR TITLE
トップページ・商品詳細ページの修正

### DIFF
--- a/app/controllers/homes_controller.rb
+++ b/app/controllers/homes_controller.rb
@@ -1,14 +1,14 @@
 class HomesController < ApplicationController
 
   def index
-    @ladies_products = Product.where(category_id: 159..338).order("created_at DESC").limit(10)
-    @mens_products = Product.where(category_id: 339..469).order("created_at DESC").limit(10)
-    @home_appliance_products = Product.where(category_id: 954..1000).order("created_at DESC").limit(10)
-    @toy_products = Product.where(category_id: 765..865).order("created_at DESC").limit(10)
+    @ladies_products = Product.where(category_id: 159..338).or(Product.where(category_id: 14..32)).or(Product.where(category_id: 1)).order("created_at DESC").limit(10)
+    @mens_products = Product.where(category_id: 339..469).or(Product.where(category_id: 33..46)).or(Product.where(category_id: 2)).order("created_at DESC").limit(10)
+    @home_appliance_products = Product.where(category_id: 954..1000).or(Product.where(category_id: 104..113)).or(Product.where(category_id: 8)).order("created_at DESC").limit(10)
+    @toy_products = Product.where(category_id: 765..865).or(Product.where(category_id: 82..92)).or(Product.where(category_id: 6)).order("created_at DESC").limit(10)
 
-    @chanel_products = Product.where(bland_id: 2447).order("created_at DESC").limit(10)
-    @louis_vuitton_products = Product.where(bland_id: 6155).order("created_at DESC").limit(10)
+    @chanel_products = Product.where(bland_id: [2447, 8386, 11783, 12826, 13210, 14002]).order("created_at DESC").limit(10)
+    @louis_vuitton_products = Product.where(bland_id: [6155, 11287, 13052, 13436, 14832]).order("created_at DESC").limit(10)
     @supreme_products = Product.where(bland_id: 8413).order("created_at DESC").limit(10)
-    @nike_products = Product.where(bland_id: 3813).order("created_at DESC").limit(10)
+    @nike_products = Product.where(bland_id: [3813, 9489, 11906, 12912, 13296, 15155]).order("created_at DESC").limit(10)
   end
 end

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -31,8 +31,9 @@
         %th
           =link_to "/category/#{@product.category.root.id}" ,class:"link"do
             =">#{@product.category.root.name}"
-          =link_to "/category/#{@product.category.parent.id}" ,class:"link"do
-            =">#{@product.category.parent.name}"
+          -if @product.category.id >= 159
+            =link_to "/category/#{@product.category.parent.id}" ,class:"link"do
+              =">#{@product.category.parent.name}"
           =link_to "/category/#{@product.category.id}" ,class:"link"do
             =">#{@product.category.name}"
       %tr


### PR DESCRIPTION
# what
＜解決した問題点＞
１、親カテゴリー、子カテゴリー、孫カテゴリー全て登録して出品しないと、トップページに反映されない点。
２、ブランドを登録して出品しても、トップページに反映されないことがある点。
３、商品詳細ページのカテゴリー欄について、親カテゴリーと子カテゴリーのみ登録して出品した場合、親レディース、子レディース、孫トップスのような誤った表示になっていた点。
# why
エラー解消。
# others
＜念のための確認事項＞
・３の問題についてです。親カテゴリーのみでは出品ができなかったので、条件分岐は”親と子”、”親と子と孫”の２パターンしか考えていません。