### PR TITLE
ヘッダー、フッターを表示切替

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -8,6 +8,10 @@
     = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
     = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
   %body
-  = render 'homes/header'
-  = yield
-  = render 'homes/footer'
+    - unless controller_name == 'registrations' || controller_name == 'sessions' || (controller_name == 'products' && (controller.action_name == 'new' || controller.action_name == 'edit' || controller.action_name == 'confirmation'))
+      = render 'homes/header'
+  
+    = yield
+
+    - unless controller_name == 'registrations' || controller_name == 'sessions' || (controller_name == 'products' && (controller.action_name == 'new' || controller.action_name == 'edit' || controller.action_name == 'confirmation'))
+      = render 'homes/footer'

--- a/app/views/products/confirmation.html.haml
+++ b/app/views/products/confirmation.html.haml
@@ -1,5 +1,5 @@
 .header_logo
-  =image_tag "/SVG/fmarket_logo_red.svg", class: "header_logo__confirmation"
+  =image_tag "svg/fmarket_logo_red.svg", class: "header_logo__confirmation"
 .trade_confirmation
   .trade_confirmation__width_main
     #h2.header_message


### PR DESCRIPTION
# What
ユーザー新規登録、ログイン
商品出品・編集・購入ページではヘッダー・フッターを表示させない。

# Why
必要な機能のみを表示して画面レイアウトをスッキリ見せるため