### PR TITLE
Payjp導入前のカードについての記述の修正

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -49,8 +49,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
   def card_confirmation
     @user = User.new
     session[:address_attributes] = user_params[:address_attributes]
-    @user.build_card = Card.new if @user.build_card.blank?
-
+    
     render 'card_confirmation'
   end
 


### PR DESCRIPTION
# What
Payjpでカード登録をする前の処理が残っておりましたので削除しました。

# Why
カード情報はPayjpに受け付けられたものをユーザーに紐付けるため